### PR TITLE
Add Time limit to scripts executed on stat1007

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ The file should look something like the below:
     dump-dir /tmp/dumps
     wdqs_host http://wdqs1005.eqiad.wmnet:8888
 
+### Scripts execution time limit
+
+All scripts have a maximum execution time set to **`one hour`**,
+after which if they are not done they fail automatically.
+The time limit is globaly set in `lib/scriptsTimeLimit.php` and included in all the scripts through `lib/load.php`.
+For reasons to this, see: [T243894](https://phabricator.wikimedia.org/T243894)
+
 ## Graphite
 
 Metrics are currently stored in the following paths in graphite:

--- a/lib/load.php
+++ b/lib/load.php
@@ -8,3 +8,4 @@ require_once __DIR__ . '/Config.php';
 require_once __DIR__ . '/Output.php';
 require_once __DIR__ . '/WikimediaGraphite.php';
 require_once __DIR__ . '/WikimediaStatsd.php';
+require_once __DIR__ . '/scriptsTimeLimit.php';

--- a/lib/scriptsTimeLimit.php
+++ b/lib/scriptsTimeLimit.php
@@ -1,0 +1,7 @@
+<?php
+
+// Setting run time limit to one hour for all scripts
+// The assumption being that the slowest script should not run more than an hour.
+
+const RUN_TIME_LIMIT = 3600;
+set_time_limit( RUN_TIME_LIMIT );


### PR DESCRIPTION
Set time limit in lib/scriptsTimeLimit.php and updated the README.md to document the config change.

Bug: T243894